### PR TITLE
[Example] Bazel javabin version mismatch example

### DIFF
--- a/android_local_test/.aswb/.idea/vcs.xml
+++ b/android_local_test/.aswb/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
   </component>
 </project>

--- a/android_local_test/WORKSPACE
+++ b/android_local_test/WORKSPACE
@@ -43,3 +43,18 @@ maven_install(
 load("@maven//:defs.bzl", "pinned_maven_install")
 
 pinned_maven_install()
+
+rules_kotlin_version = "legacy-1.3.0"
+rules_kotlin_sha = "4fd769fb0db5d3c6240df8a9500515775101964eebdf85a3f9f0511130885fde"
+http_archive(
+    name = "io_bazel_rules_kotlin",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/archive/%s.zip" % rules_kotlin_version],
+    type = "zip",
+    strip_prefix = "rules_kotlin-%s" % rules_kotlin_version,
+    sha256 = rules_kotlin_sha,
+)
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+kotlin_repositories() # if you want the default. Otherwise see custom kotlinc distribution below
+kt_register_toolchains() # to use the default toolchain, otherwise see toolchains below
+

--- a/android_local_test/src/main/BUILD
+++ b/android_local_test/src/main/BUILD
@@ -12,3 +12,12 @@ android_library(
         artifact("androidx.annotation:annotation"),
     ],
 )
+
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "example_kotlin",
+    srcs = glob(["java/com/example/bazel/ExampleKotlinClass.kt"]),
+    deps = [
+    ],
+)

--- a/android_local_test/src/main/java/com/example/bazel/ExampleKotlinClass.kt
+++ b/android_local_test/src/main/java/com/example/bazel/ExampleKotlinClass.kt
@@ -1,0 +1,3 @@
+package com.example.bazel
+
+class ExampleKotlinClass {}


### PR DESCRIPTION
Example code for https://github.com/bazelbuild/bazel/issues/11382

Repro steps:
1. Build kotlin target `bazelisk build //src/main:example_kotlin -s`
2. Open the generated `builder` runfile (path can be found in subcommand)
```
e.g.
(cd /.../execroot/__main__ && \
  exec env - \
    LC_CTYPE=en_US.UTF-8 \
  bazel-out/host/bin/external/io_bazel_rules_kotlin/src/main/kotlin/builder 
```

In builder file, we can see that `JAVABIN=${JAVABIN:-${JAVA_RUNFILES}/remotejdk11_macos/bin/java}` is always using the built-in jdk11 as the javabin